### PR TITLE
Fix incorrect total session calculation for 30-minute differences

### DIFF
--- a/app/classes/Time.tsx
+++ b/app/classes/Time.tsx
@@ -74,6 +74,10 @@ class Time {
       minuteDifference++;
       if (alterMinutes === 60) {
         alterMinutes = 0;
+        hourDifference--; // Adjust hour difference when minutes wrap around
+        if (hourDifference < 0) {
+          hourDifference = 23; // Handle negative hour difference
+        }
       }
     }
     // return the hours and minutes difference

--- a/app/rythm-rise/page.tsx
+++ b/app/rythm-rise/page.tsx
@@ -57,6 +57,8 @@ const Page = () => {
 
     // Calculate pomodoro schedule
     const difference = hourStart.getDifference(hourEnd);
+    console.log(difference);
+
     const totalFreeTime = difference.hours * 60 + difference.minutes;
     const totalLearnTime = (totalFreeTime * learnPercentage) / 100;
     const totalSessions = Math.floor(totalLearnTime / maxFocus);


### PR DESCRIPTION
Adjustments ensure that the hour difference correctly wraps around when minutes exceed 60, resolving the issue where total sessions were inaccurately calculated as 90 minutes instead of 30.

Fixes #9