### PR TITLE
Refactor StarSelection component to allow unselecting stars

### DIFF
--- a/components/pages/sol-cycle/StarSelection.tsx
+++ b/components/pages/sol-cycle/StarSelection.tsx
@@ -1,7 +1,9 @@
 import StarSelect from "@/app/components/StarSelect";
 import Tooltip from "@/app/components/Tooltip";
+import { Button } from "@/components/ui/button";
 import clsx from "clsx";
 import { Dispatch, SetStateAction, useState } from "react";
+import { X } from "lucide-react";
 
 interface StarSelectionProps {
   starSelected: Star | null;
@@ -13,11 +15,16 @@ const StarSelection = ({ starSelected, setStarSelected }: StarSelectionProps) =>
 
   return (
     <div className="relative" data-testid="star-selection">
-      <Tooltip text="Change Active Star">
-        <button onClick={() => setOpenStarSelect(!openStarSelect)} className={clsx("font-medium transition-colors cursor-pointer")}>
-          {starSelected ? starSelected.name : "Select Star"}
-        </button>
-      </Tooltip>
+      <div className="flex items-center gap-2 ml-8">
+        <Tooltip text="Change Active Star">
+          <button onClick={() => setOpenStarSelect(!openStarSelect)} className={clsx("font-medium transition-colors cursor-pointer")}>
+            {starSelected ? starSelected.name : "Select Star"}
+          </button>
+        </Tooltip>
+        <Button className="size-6" size="icon" variant="outline" onClick={() => setStarSelected(null)}>
+          <X />
+        </Button>
+      </div>
       {openStarSelect && (
         <StarSelect
           starSelected={(star) => {


### PR DESCRIPTION
The refactor of the StarSelection component enhances its layout and introduces a button to unselect a star, addressing the need for improved user interaction in the Sol Cycle.

Resolves #40